### PR TITLE
Add normal support for raycasting upwards

### DIFF
--- a/GraphicsRaycast/GraphicRaycastShader.shader
+++ b/GraphicsRaycast/GraphicRaycastShader.shader
@@ -33,7 +33,7 @@
                float3 wNormal = UnityObjectToWorldNormal(i.normal.xyz);
 
 			   //Remap from [-1 to 1] to [0 to 1]
-			   wNormal.rb = wNormal.rb * 0.5 + 0.5;		
+			   wNormal.rgb = wNormal.rgb * 0.5 + 0.5;		
                
                float depth = Linear01Depth(tex2Dproj(_CameraDepthTexture, UNITY_PROJ_COORD(i.scrPos)).r);
 

--- a/GraphicsRaycast/GraphicsRaycast.cs
+++ b/GraphicsRaycast/GraphicsRaycast.cs
@@ -116,12 +116,9 @@ public static class GraphicsRaycast
         //Grab initial unscaled normal
         hit.normal = new Vector3(outputColor.r, outputColor.g, outputColor.b);
 
-        //Scale X and Z values back to -1 to 1
+        //Scale values back to -1 to 1
         hit.normal = Vector3.Scale(hit.normal, Vector3.one * 2f);
         hit.normal = hit.normal - Vector3.one;
-
-        //Leave Y value in current range. Values below 0 are never returned
-        hit.normal = new Vector3(hit.normal.x, outputColor.g, hit.normal.z);
 
         RenderTexture.active = null;
         outputColor.a = 1f; //Useful so gizmos don't turn transparent


### PR DESCRIPTION
Raycasts from below horizon (facing upwards) previously returned incorrect normals, due to the green (y) value not being considered.
Before:
![Before Changes](https://github.com/staggartcreations/Graphics-Raycast/assets/98048916/a998fb76-13fa-425e-84a9-9f67715cb461)
After:
![After Changes](https://github.com/staggartcreations/Graphics-Raycast/assets/98048916/c9e0c3f6-7560-43eb-b5c5-5b59dd14b383)